### PR TITLE
Datalog shrink data

### DIFF
--- a/src/com/winterwell/es/client/TransformRequestBuilder.java
+++ b/src/com/winterwell/es/client/TransformRequestBuilder.java
@@ -46,15 +46,17 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 	 * This is locked to the `time` field ??do we want more flexibility
 	 * @return this
 	*/
-	public TransformRequestBuilder setBody(String srcIndex, String destIndex, List<String> terms, String interval) {		
-		// counts ??do we want sums in places??
+	public TransformRequestBuilder setBody(String srcIndex, String destIndex, List<String> aggs, List<String> terms, String interval) {		
 		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("sum", new ArrayMap("field", "count")));
+		for (String agg : aggs) {
+			aggregations.put(agg, new ArrayMap("sum", new ArrayMap("field", agg)));
+		}
 
 		ArrayMap group_by = new ArrayMap();
 		for (String term : terms) {
-			group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term)));
+			//group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term)));
 			// for ES version >= 7.10.0, missing_bucket attribute supported to not ignore documents with null field
-			//group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term, "missing_bucket", true)));
+			group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term, "missing_bucket", true)));
 		}
 		if ( ! Utils.isBlank(interval)) {
 			group_by.put("time", new ArrayMap("date_histogram", new ArrayMap(
@@ -74,9 +76,8 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 		return this;
 	}
 	
-	// Similar to setBody function, but with painless script support to not ignore documents with null fields
+	// Similar to setBody function, but with painless script support in case for ES version < 7.10.0
 	public TransformRequestBuilder setBodyWithPainless(String srcIndex, String destIndex, List<String> aggs, List<String> terms, String interval) {		
-		// counts ??do we want sums in places??
 		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("sum", new ArrayMap("field", "count")));
 		for (String agg : aggs) {
 			aggregations.put(agg, new ArrayMap("sum", new ArrayMap("field", agg)));

--- a/src/com/winterwell/es/client/TransformRequestBuilder.java
+++ b/src/com/winterwell/es/client/TransformRequestBuilder.java
@@ -48,11 +48,49 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 	*/
 	public TransformRequestBuilder setBody(String srcIndex, String destIndex, List<String> terms, String interval) {		
 		// counts ??do we want sums in places??
-		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("value_count", new ArrayMap("field", "count")));
+		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("sum", new ArrayMap("field", "count")));
 
 		ArrayMap group_by = new ArrayMap();
 		for (String term : terms) {
 			group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term)));
+		}
+		if ( ! Utils.isBlank(interval)) {
+			group_by.put("time", new ArrayMap("date_histogram", new ArrayMap(
+					"field", "time", 
+					"fixed_interval", interval
+					)));
+		}
+		//Map 
+		setBodyMap(new ArrayMap(
+			"source", new ArrayMap("index", srcIndex),
+			"dest", new ArrayMap("index", destIndex),
+			"pivot", new ArrayMap(
+					"group_by", group_by, 
+					"aggregations", aggregations
+					)
+			));
+		return this;
+	}
+	
+	/**
+	 * Set the body of a transform request. Does not ignore documents with null fields
+	 * @param srcIndex index source (where the data comes from)
+	 * @param destIndex index destination (where the aggregated data will go)
+	 * @param terms the terms which you want to group by (i.e. what fields will get kept)
+	 * @param interval (optional) if want to group by date histogram, specify interval format, e.g. "24h"
+	 * @return this
+	*/
+	public TransformRequestBuilder setBodyWithPainless(String srcIndex, String destIndex, List<String> terms, String interval) {		
+		// counts ??do we want sums in places??
+		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("sum", new ArrayMap("field", "count")));
+
+		ArrayMap group_by = new ArrayMap();
+		String script;
+		for (String term : terms) {
+			script = "if (doc[\u0027"+term+"\u0027].size() == 0) {return \"\";}return doc[\u0027"+term+"\u0027].value;";
+			group_by.put(term, new ArrayMap("terms", new ArrayMap("script", new ArrayMap(
+					"source", script,
+					"lang", "painless"))));
 		}
 		if ( ! Utils.isBlank(interval)) {
 			group_by.put("time", new ArrayMap("date_histogram", new ArrayMap(

--- a/src/com/winterwell/es/client/TransformRequestBuilder.java
+++ b/src/com/winterwell/es/client/TransformRequestBuilder.java
@@ -38,7 +38,7 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 	}
 	
 	/**
-	 * Set the body of a transform request. Uses count aggregations (what about sum??)
+	 * Set the body of a transform request. Uses sum aggregation
 	 * @param srcIndex index source (where the data comes from)
 	 * @param destIndex index destination (where the aggregated data will go)
 	 * @param terms the terms which you want to group by (i.e. what fields will get kept)
@@ -53,6 +53,8 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 		ArrayMap group_by = new ArrayMap();
 		for (String term : terms) {
 			group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term)));
+			// for ES version >= 7.10.0, missing_bucket attribute supported to not ignore documents with null field
+			//group_by.put(term, new ArrayMap("terms", new ArrayMap("field", term, "missing_bucket", true)));
 		}
 		if ( ! Utils.isBlank(interval)) {
 			group_by.put("time", new ArrayMap("date_histogram", new ArrayMap(
@@ -72,14 +74,7 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 		return this;
 	}
 	
-	/**
-	 * Set the body of a transform request. Does not ignore documents with null fields
-	 * @param srcIndex index source (where the data comes from)
-	 * @param destIndex index destination (where the aggregated data will go)
-	 * @param terms the terms which you want to group by (i.e. what fields will get kept)
-	 * @param interval (optional) if want to group by date histogram, specify interval format, e.g. "24h"
-	 * @return this
-	*/
+	// Similar to setBody function, but with painless script support to not ignore documents with null fields
 	public TransformRequestBuilder setBodyWithPainless(String srcIndex, String destIndex, List<String> terms, String interval) {		
 		// counts ??do we want sums in places??
 		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("sum", new ArrayMap("field", "count")));

--- a/src/com/winterwell/es/client/TransformRequestBuilder.java
+++ b/src/com/winterwell/es/client/TransformRequestBuilder.java
@@ -75,9 +75,12 @@ public class TransformRequestBuilder extends ESHttpRequest<TransformRequestBuild
 	}
 	
 	// Similar to setBody function, but with painless script support to not ignore documents with null fields
-	public TransformRequestBuilder setBodyWithPainless(String srcIndex, String destIndex, List<String> terms, String interval) {		
+	public TransformRequestBuilder setBodyWithPainless(String srcIndex, String destIndex, List<String> aggs, List<String> terms, String interval) {		
 		// counts ??do we want sums in places??
 		ArrayMap aggregations = new ArrayMap("count", new ArrayMap("sum", new ArrayMap("field", "count")));
+		for (String agg : aggs) {
+			aggregations.put(agg, new ArrayMap("sum", new ArrayMap("field", agg)));
+		}
 
 		ArrayMap group_by = new ArrayMap();
 		String script;

--- a/test/com/winterwell/es/client/TransformRequestBuilderTest.java
+++ b/test/com/winterwell/es/client/TransformRequestBuilderTest.java
@@ -80,8 +80,11 @@ public class TransformRequestBuilderTest {
 		terms.add("domain");
 		terms.add("os");
 		
+		// specify some terms that we want to sum
+		ArrayList<String> aggs = new ArrayList<String>();
+		
 		// specify source and destination
-		trb.setBody(INDEX, "datalog.transformed", terms, "");
+		trb.setBody(INDEX, "datalog.transformed", aggs, terms, "");
 		trb.setDebug(true);
 		IESResponse response = trb.get();
 		
@@ -103,8 +106,11 @@ public class TransformRequestBuilderTest {
 		terms.add("domain");
 		terms.add("os");
 		
+		// specify some terms that we want to sum
+		ArrayList<String> aggs = new ArrayList<String>();
+		
 		// specify source and destination
-		trb.setBody(INDEX, "datalog.test_transformed", terms, "");
+		trb.setBody(INDEX, "datalog.test_transformed", aggs, terms, "");
 		trb.setDebug(true);
 		IESResponse response = trb.get();
 		assert response.isAcknowledged();


### PR DESCRIPTION
Created a setBodyWithPainless method in TransformRequestBuilder class. This function prevents documents with null fields being ignored during transform. 

For ES version >= 7.10.0, the transform API will support the `missing_bucket` attribute. This is already defined in the setBody method but commented out. After we've upgraded our ES version, we could uncomment the line. (easier to use than the painless script) 