### PR TITLE
Support boost parameters in term queries

### DIFF
--- a/config/version.properties
+++ b/config/version.properties
@@ -1,0 +1,9 @@
+#Wed May 19 20:55:04 BST 2021
+lastCommit.time=13 May 2021 18\:09\:47 GMT
+lastCommit.author=Daniel Winterstein
+lastCommit.subject=jetty-wip
+origin=MacBook-Air.local
+publishDate=2021-05-19T19\:55\:04Z
+lastCommit.hash=413bc093830d2c86e0fe29dc46321adf243e315a
+branch=master
+lastCommit.branch=master

--- a/src/com/winterwell/es/client/query/ESQueryBuilders.java
+++ b/src/com/winterwell/es/client/query/ESQueryBuilders.java
@@ -76,7 +76,29 @@ public class ESQueryBuilders {
 		Map must = new ArrayMap("term", new ArrayMap(field, value));
 		return new ESQueryBuilder(must);
 	}
-	
+
+	/**
+	 * Find exact term matches.
+	 *
+	 * Note: When querying full text fields, use the match query instead, which understands how the field has been analyzed.
+	 *
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-term-query.html
+	 * @param field
+	 * @param value
+	 * @param boost - Floating point number used to decrease or increase the relevance scores of a query. You can use the
+	 *  boost parameter to adjust relevance scores for searches containing two or more queries. Boost values are relative to
+	 *  the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0
+	 *  increases the relevance score.
+	 * @return
+	 */
+	public static ESQueryBuilder termQuery(String field, Object value, Object boost) {
+		Map termValue = new ArrayMap(field, new ArrayMap(
+				"value", value,
+				"boost", boost));
+		Map must = new ArrayMap("term", termValue);
+		return new ESQueryBuilder(must);
+	}
+
 	/**
 	 * match or multi_match with * all fields
 	 * https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query.html


### PR DESCRIPTION
(Required for ordering SoGive search queries by impact)
